### PR TITLE
バリデーション修正: 踊り字「々」を含む名前に対応

### DIFF
--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -6,7 +6,7 @@ export const searchFormSchema = z.object({
     .min(1, '名前を入力してください')
     .max(100, '名前は100文字以内で入力してください')
     .regex(
-      /^[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\s\-]+$/,
+      /^[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\u3005\s\-]+$/,
       '有効な名前を入力してください（ひらがな、カタカナ、漢字、英字のみ）'
     ),
   location: z.string().optional(),


### PR DESCRIPTION
## 概要
「佐々木」の「々」文字がバリデーションエラーになる問題を修正しました。

## 問題
- フォームで「佐々木」と入力すると「有効な名前を入力してください」エラーが発生
- 踊り字（々）のUnicode文字（\u3005）が正規表現に含まれていなかった

## 解決方法
- `src/lib/validations.ts` の正規表現に `\u3005` を追加
- 修正前: `/^[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\s\-]+$/`
- 修正後: `/^[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\u3005\s\-]+$/`

## 対応する名前の例
- 佐々木（ささき）
- 田々川（たたがわ） 
- その他踊り字を含む日本の姓名

## テスト方法
1. SEO分析フォームで「佐々木」と入力
2. バリデーションエラーが発生しないことを確認
3. 正常に分析が実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)